### PR TITLE
some tiny patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# object files
+*.[oa]
+
+# AVR executables
+*.elf
+*.hex

--- a/example(multiple usart).c
+++ b/example(multiple usart).c
@@ -7,6 +7,9 @@
 
 #include "usart.h"
 
+
+#define BUFF_SIZE   25
+
 const char foo_string[] PROGMEM = "Unluckily gcc string polling doesn't work for PROGMEM/PSTR() strings";
 
 int main(void)
@@ -28,8 +31,8 @@ int main(void)
 
 	printf("hello from printf\n");
 	
-	char buffer[25];
-	uart1_gets(buffer, 25); // read at most 24 bytes from buffer (CR,LF will not be cut)
+	char buffer[BUFF_SIZE];
+	uart1_gets(buffer, BUFF_SIZE); // read at most 24 bytes from buffer (CR,LF will not be cut)
 	
 	int a;
 	
@@ -44,7 +47,7 @@ int main(void)
 	{
 		uart0_puts("bytes waiting in receiver buffer : ");
 		uart0_putint(uart0_AvailableBytes()); // ask for bytes waiting in receiver buffer
-		uart0_getln(buffer, 25); // read 24 bytes or one line from usart buffer
+		uart0_getln(buffer, BUFF_SIZE); // read 24 bytes or one line from usart buffer
 		
 		if (!strcmp(buffer, "people who annoy you"))
 		{

--- a/example(single usart).c
+++ b/example(single usart).c
@@ -7,6 +7,9 @@
 
 #include "usart.h"
 
+
+#define BUFF_SIZE   25
+
 const char foo_string[] PROGMEM = "Unluckily gcc string polling doesn't work for PROGMEM/PSTR() strings";
 
 int main(void)
@@ -27,8 +30,8 @@ int main(void)
 	
 	printf("hello from printf\n");
 
-	char buffer[25];
-	uart_gets(buffer, 25); // read at most 24 bytes from buffer (CR,LF will not be cut)
+	char buffer[BUFF_SIZE];
+	uart_gets(buffer, BUFF_SIZE); // read at most 24 bytes from buffer (CR,LF will not be cut)
 	
 	int a;
 	
@@ -43,7 +46,7 @@ int main(void)
 	{
 		uart_puts("bytes waiting in receiver buffer : ");
 		uart_putint(uart_AvailableBytes()); // ask for bytes waiting in receiver buffer
-		uart_getln(buffer, 25); // read 24 bytes or one line from usart buffer 
+		uart_getln(buffer, BUFF_SIZE); // read 24 bytes or one line from usart buffer 
 		
 		if (!strcmp(buffer, "people who annoy you"))
 		{

--- a/example(xmodem).c
+++ b/example(xmodem).c
@@ -4,12 +4,12 @@
 
 #include "usart.h"
 
-#define SETUP_RETRIES_DELAY 1000 // in ms
+#define SETUP_RETRIES_DELAY 1000 /* in ms */
 #define SETUP_CRC_RETRIES_TO_FALLBACK 15
 #define SETUP_CKSUM_RETRIES_TO_GIVE_UP 2
 
-#define PACKET_RETRY_DELAY 1000 // in ms // timeouts if nothing is received or packet is too short
-#define PACKET_MAX_TIMEOUT_RETRANSMITS 15 // 0-255 
+#define PACKET_RETRY_DELAY 1000 /* in ms / timeouts if nothing is received or packet is too short */
+#define PACKET_MAX_TIMEOUT_RETRANSMITS 15 /* 0-255 */
 
 #define SOH 0x01
 #define EOT 0x04


### PR DESCRIPTION
Added BUFF_SIZE macro in examples - for safety.

Question: Is that a mistake (?) in:
https://github.com/Leopardus4/AVR-UART-lib/blob/1578db4a5592356f0572a9761f000fb848982efb/usart.h#L18
#define BAUD_CALC_FAST(x) ((F_CPU)/(BAUD*16UL)-1)
"BAUD" probably should be "x"

Best regards
Leopardus